### PR TITLE
Fix $PATH and put .profile script in the right place.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -39,5 +39,5 @@ rm -f $ZIP_LOCATION
 indent "Downloaded"
 
 topic "Creating chromedriver export scripts"
-echo "export PATH=\$PATH:$BIN_DIR" >> /app/.profile.d/chromedriver.sh
+echo "export PATH=\$PATH:/app/.chromedriver/bin" >> /app/.profile.d/chromedriver.sh
 indent "Created"

--- a/bin/compile
+++ b/bin/compile
@@ -40,5 +40,5 @@ indent "Downloaded"
 
 topic "Creating chromedriver export scripts"
 mkdir -p $BUILD_DIR/.profile.d
-echo "export PATH=\$PATH:/app/.chromedriver/bin" >> $BUILD_DIR/.profile.d/chromedriver.sh
+echo "export PATH=\$PATH:\$HOME/.chromedriver/bin" >> $BUILD_DIR/.profile.d/chromedriver.sh
 indent "Created"

--- a/bin/compile
+++ b/bin/compile
@@ -39,5 +39,6 @@ rm -f $ZIP_LOCATION
 indent "Downloaded"
 
 topic "Creating chromedriver export scripts"
-echo "export PATH=\$PATH:/app/.chromedriver/bin" >> /app/.profile.d/chromedriver.sh
+mkdir -p $BUILD_DIR/.profile.d
+echo "export PATH=\$PATH:/app/.chromedriver/bin" >> $BUILD_DIR/.profile.d/chromedriver.sh
 indent "Created"


### PR DESCRIPTION
Previously, the export script would append `$BUILD_DIR/app/.chromedriver/bin` which resolves to a temp directory. In a CI run, that directory remains available for the test, but it doesn't exist for a normal build. Additionally, we were saving the profile script in `/app` (instead of $BUILD_DIR), which won't be persisted during a normal build.