### PR TITLE
Fix indent usage

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -32,7 +32,7 @@ else
   LATEST="https://chromedriver.storage.googleapis.com/LATEST_RELEASE"
   VERSION=`curl -s $LATEST`
 fi
-indent "Version $VERSION"
+echo "Version $VERSION" | indent
 
 topic "Downloading chromedriver v$VERSION"
 ZIP_URL="https://chromedriver.storage.googleapis.com/$VERSION/chromedriver_linux64.zip"
@@ -40,9 +40,9 @@ ZIP_LOCATION="/tmp/chromedriver.zip"
 curl -s -o $ZIP_LOCATION $ZIP_URL
 unzip -o $ZIP_LOCATION -d $BIN_DIR
 rm -f $ZIP_LOCATION
-indent "Downloaded"
+echo "Downloaded" | indent
 
 topic "Creating chromedriver export scripts"
 mkdir -p $BUILD_DIR/.profile.d
 echo "export PATH=\$PATH:\$HOME/.chromedriver/bin" >> $BUILD_DIR/.profile.d/chromedriver.sh
-indent "Created"
+echo "Created" | indent


### PR DESCRIPTION
I referred to [heroku-buildpack-google-chrome](https://github.com/heroku/heroku-buildpack-google-chrome/blob/737a426cec8327daa80a2a79a0f695b45f9bc3d1/bin/compile#L119).

## Before

```
remote: -----> chromedriver app detected        
remote: -----> Looking up latest chromedriver version...        
remote: -----> Downloading chromedriver v74.0.3729.6...        
remote: Archive:  /tmp/chromedriver.zip        
remote:   inflating: /tmp/build_1f3163a77e0c7ff00504af41590de2dc/.chromedriver/bin/chromedriver  
remote: -----> Creating chromedriver export scripts...        
```

## After

```
remote: -----> chromedriver app detected        
remote: -----> Looking up latest chromedriver version...        
remote:        Version 74.0.3729.6        
remote: -----> Downloading chromedriver v74.0.3729.6...        
remote: Archive:  /tmp/chromedriver.zip        
remote:   inflating: /tmp/build_7912393887c2f380c6607ac7baf88fe9/.chromedriver/bin/chromedriver  
remote:        Downloaded        
remote: -----> Creating chromedriver export scripts...        
remote:        Created        
```
