### PR TITLE
Add validator for chromedriver binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ This buildpack installs
  - [heroku-buildpack-xvfb-google-chrome](https://github.com/heroku/heroku-buildpack-xvfb-google-chrome)
    to run Chrome against a virtual window server
 
+The `chromedriver` binary depends on Chrome. You need to put Chrome buildpack first in the order.
+
+e.g;
+
+1. https://github.com/heroku/heroku-buildpack-google-chrome.git
+2. https://github.com/heroku/heroku-buildpack-chromedriver.git
 
 ## Configuring the downloaded version of chromedriver.
 

--- a/bin/compile
+++ b/bin/compile
@@ -46,3 +46,7 @@ topic "Creating chromedriver export scripts"
 mkdir -p $BUILD_DIR/.profile.d
 echo "export PATH=\$PATH:\$HOME/.chromedriver/bin" >> $BUILD_DIR/.profile.d/chromedriver.sh
 indent "Created"
+
+topic "Validating chromedriver"
+$BIN_DIR/chromedriver --version | indent
+echo "Validated" | indent

--- a/bin/compile
+++ b/bin/compile
@@ -47,6 +47,15 @@ mkdir -p $BUILD_DIR/.profile.d
 echo "export PATH=\$PATH:\$HOME/.chromedriver/bin" >> $BUILD_DIR/.profile.d/chromedriver.sh
 indent "Created"
 
-topic "Validating chromedriver"
-$BIN_DIR/chromedriver --version | indent
-echo "Validated" | indent
+if [ -x "$GOOGLE_CHROME_SHIM" ]; then
+  topic "Validating chromedriver"
+  rm $BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu/libnss3.so
+  $BIN_DIR/chromedriver --version | indent
+  echo "Validated" | indent
+else
+  cat <<WARNING
+You should consider ordering heroku-buildpack-google-chrome before heroku-buildpack-chromedriver. Doing so will enable validation of the chromedriver binary in the build process.
+
+See https://github.com/heroku/heroku-buildpack-chromedriver/blob/master/README.md
+WARNING
+fi

--- a/bin/compile
+++ b/bin/compile
@@ -47,7 +47,7 @@ mkdir -p $BUILD_DIR/.profile.d
 echo "export PATH=\$PATH:\$HOME/.chromedriver/bin" >> $BUILD_DIR/.profile.d/chromedriver.sh
 indent "Created"
 
-if [ -x "$GOOGLE_CHROME_SHIM" ]; then
+if [ -x "$BUILD_DIR/.apt/usr/bin/google-chrome" ]; then
   topic "Validating chromedriver"
   rm $BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu/libnss3.so
   $BIN_DIR/chromedriver --version | indent


### PR DESCRIPTION
Hi Heroku,

I added validator for chromedriver binary. This PR similar to https://github.com/heroku/heroku-buildpack-google-chrome/pull/72 .

This change gives the following logs.

```
remote: -----> Validating chromedriver...
remote:        ChromeDriver 74.0.3729.6 (255758eccf3d244491b8a1317aa76e1ce10d57e9-refs/branch-heads/3729@{#29})
remote:        Validated
```

You can try the invalid case with the following patch.

```patch
diff --git a/bin/compile b/bin/compile
index b029556..f698316 100644
--- a/bin/compile
+++ b/bin/compile
@@ -48,5 +48,6 @@ echo "export PATH=\$PATH:\$HOME/.chromedriver/bin" >> $BUILD_DIR/.profile.d/chro
 indent "Created"
 
 topic "Validating chromedriver"
+rm $BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu/libnss3.so
 $BIN_DIR/chromedriver --version | indent
 echo "Validated" | indent
```

:bulb: `libnss3.so` is installed by [heroku-buildpack-google-chrome](https://github.com/heroku/heroku-buildpack-google-chrome). It's NOT heroku-buildpack-chromedriver.

Deployment fails with the following error. Users can avoid releasing invalid Chrome binary.

```
remote: -----> Validating chromedriver...
remote: /tmp/build_fe24801fe10ef8c25e0fe63a27043bbd/.chromedriver/bin/chromedriver: error while loading shared libraries: libnss3.so: cannot open shared object file: No such file or directory
remote:  !     Push rejected, failed to compile chromedriver app.
remote:
remote:  !     Push failed
```

:warning: This PR gives safety deployment. However, it gives order dependency with Chrome buildpack. If users fail to deploy, they need to change the buildpack order.
