### PR TITLE
making chromedriver for 84 version of chrome

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -35,7 +35,7 @@ fi
 indent "Version $VERSION"
 
 topic "Downloading chromedriver v$VERSION"
-ZIP_URL="https://chromedriver.storage.googleapis.com/84.0.4147.30/chromedriver_linux64.zip"
+ZIP_URL="https://chromedriver.storage.googleapis.com/86.0.4240.22/chromedriver_linux64.zip"
 ZIP_LOCATION="/tmp/chromedriver.zip"
 curl -s -o $ZIP_LOCATION $ZIP_URL
 unzip -o $ZIP_LOCATION -d $BIN_DIR

--- a/bin/compile
+++ b/bin/compile
@@ -35,7 +35,7 @@ fi
 indent "Version $VERSION"
 
 topic "Downloading chromedriver v$VERSION"
-ZIP_URL="https://chromedriver.storage.googleapis.com/86.0.4240.22/chromedriver_linux64.zip"
+ZIP_URL="https://chromedriver.storage.googleapis.com/88.0.4324.96/chromedriver_linux64.zip"
 ZIP_LOCATION="/tmp/chromedriver.zip"
 curl -s -o $ZIP_LOCATION $ZIP_URL
 unzip -o $ZIP_LOCATION -d $BIN_DIR

--- a/bin/compile
+++ b/bin/compile
@@ -35,7 +35,7 @@ fi
 indent "Version $VERSION"
 
 topic "Downloading chromedriver v$VERSION"
-ZIP_URL="https://chromedriver.storage.googleapis.com/$VERSION/chromedriver_linux64.zip"
+ZIP_URL="https://chromedriver.storage.googleapis.com/84.0.4147.30/chromedriver_linux64.zip"
 ZIP_LOCATION="/tmp/chromedriver.zip"
 curl -s -o $ZIP_LOCATION $ZIP_URL
 unzip -o $ZIP_LOCATION -d $BIN_DIR


### PR DESCRIPTION
Chromedriver getting installed was 85th version, whereas the stable version is 84, hence the correction.