### PR TITLE
Download the latest supported chromedriver for the version of Chrome installed by heroku-buildpack-google-chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This buildpack installs
  
  - [heroku-buildpack-google-chrome](https://github.com/heroku/heroku-buildpack-google-chrome) 
    to run Chrome with the `--headless` flag
+    - Make sure you've installed heroku-buildpack-google-chrome BEFORE heroku-buildpack-chromedriver, so it can install the latest supported chromedriver for the verison of Chrome installed previously.
  - [heroku-buildpack-xvfb-google-chrome](https://github.com/heroku/heroku-buildpack-xvfb-google-chrome)
    to run Chrome against a virtual window server
 
@@ -18,8 +19,13 @@ This buildpack installs
 By default, this buildpack will download the latest release, which is provided
 by [Google](https://chromedriver.storage.googleapis.com/LATEST_RELEASE).
 
+If you've installed heroku-buildpack-google-chrome before this buildpack, it will download the latest supported chromedriver which has the same build version of the Chrome installed previously.
+    - Here's the rule of the version number of Google Chrome: <https://www.chromium.org/developers/version-numbers>
+    - Here's the rule of version selection implemented in this buildpack: <http://chromedriver.chromium.org/downloads/version-selection>
+        - This only works for stable version and beta version of Chrome as describe in this document.
+
 You can control the specific version by setting the `CHROMEDRIVER_VERSION`
-variable to an explicit version e.g. `2.39`.
+environment variable to an explicit version e.g. `2.39`.
 
 
 ## Releasing a new version

--- a/bin/compile
+++ b/bin/compile
@@ -27,6 +27,13 @@ mkdir -p $BIN_DIR
 
 if [ -f $ENV_DIR/CHROMEDRIVER_VERSION ]; then
   VERSION=$(cat $ENV_DIR/CHROMEDRIVER_VERSION)
+elif [ ! -z $CHROME_VERSION ]; then
+  topic "$CHROME_VERSION is the version of Google Chrome installed by heroku-buildpack-google-chrome"
+  # There might be no same version chromedriver as $CHROME_VERSION exists.
+  # Using the version selection rules decribed in <http://chromedriver.chromium.org/downloads/version-selection> at here.
+  BUILD_VERSION=`echo $CHROME_VERSION | cut -d "." -f 1-3`
+  SUPPORTED="https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$BUILD_VERSION"
+  VERSION=`curl -s $SUPPORTED`
 else
   topic "Looking up latest chromedriver version"
   LATEST="https://chromedriver.storage.googleapis.com/LATEST_RELEASE"


### PR DESCRIPTION
So, we can avoid the chromedriver version mismatch problem in a general situation.

The detail is in: https://github.com/heroku/heroku-buildpack-google-chrome/pull/95

This PR should not be merged until the upstream repo PR been merged.