### PR TITLE
Update compile to download the latest Chromedriver from the new location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
-
+- Update Google's URL to reflect new location for chromedriver downloads
 - Remove Circle CI and add GitHub Action for simple CI
 - Make `bin/compile` executable
 - 4/6/2021 Remove Travis
 - Introduce CHANGELOG.md
-

--- a/bin/compile
+++ b/bin/compile
@@ -30,7 +30,7 @@ if [ -f $ENV_DIR/CHROMEDRIVER_VERSION ]; then
 else
   topic "Looking up latest chromedriver version"
   LATEST="https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json"
-  VERSION=`curl -s https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json | jq -r '.channels.Stable.version'
+  VERSION=$(curl --silent --show-error --fail --retry 3 --retry-connrefused --connect-timeout 10 "${LATEST}" | jq -r '.channels.Stable.version')
 fi
 indent "Version $VERSION"
 

--- a/bin/compile
+++ b/bin/compile
@@ -29,13 +29,13 @@ if [ -f $ENV_DIR/CHROMEDRIVER_VERSION ]; then
   VERSION=$(cat $ENV_DIR/CHROMEDRIVER_VERSION)
 else
   topic "Looking up latest chromedriver version"
-  LATEST="https://chromedriver.storage.googleapis.com/LATEST_RELEASE"
-  VERSION=`curl -s $LATEST`
+  LATEST="https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json"
+  VERSION=`curl -s $LATEST | grep -Eo '"channel":"Stable","version"[^,]*' | grep -Eo '[^:]*$' | tr -d '"'`
 fi
 indent "Version $VERSION"
 
 topic "Downloading chromedriver v$VERSION"
-ZIP_URL="https://chromedriver.storage.googleapis.com/$VERSION/chromedriver_linux64.zip"
+ZIP_URL="https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/$VERSION/linux64/chromedriver-linux64.zip"
 ZIP_LOCATION="/tmp/chromedriver.zip"
 curl -s -o $ZIP_LOCATION $ZIP_URL
 unzip -o $ZIP_LOCATION -d $BIN_DIR

--- a/bin/compile
+++ b/bin/compile
@@ -30,7 +30,7 @@ if [ -f $ENV_DIR/CHROMEDRIVER_VERSION ]; then
 else
   topic "Looking up latest chromedriver version"
   LATEST="https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json"
-  VERSION=`curl -s $LATEST | grep -Eo '"channel":"Stable","version"[^,]*' | grep -Eo '[^:]*$' | tr -d '"'`
+  VERSION=`curl -s https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json | jq -r '.channels.Stable.version'
 fi
 indent "Version $VERSION"
 


### PR DESCRIPTION
With the release of [Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing/), versions of `chromedriver` > 114 are found at a new location. This PR updates the `bin/compile` script to look in the new location for version and binary.