### PR TITLE
Add -j to unzip command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Update `unzip` step in `bin/compile` to remove superfluous directory from decompressed chromdriver path
 - Update Google's URL to reflect new location for chromedriver downloads
 - Remove Circle CI and add GitHub Action for simple CI
 - Make `bin/compile` executable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-- Update `unzip` step in `bin/compile` to remove superfluous directory from decompressed chromdriver path
+- Update `unzip` step in `bin/compile` to remove superfluous directory from decompressed chromedriver path
 - Update Google's URL to reflect new location for chromedriver downloads
 - Remove Circle CI and add GitHub Action for simple CI
 - Make `bin/compile` executable

--- a/bin/compile
+++ b/bin/compile
@@ -38,7 +38,7 @@ topic "Downloading chromedriver v$VERSION"
 ZIP_URL="https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/$VERSION/linux64/chromedriver-linux64.zip"
 ZIP_LOCATION="/tmp/chromedriver.zip"
 curl -s -o $ZIP_LOCATION $ZIP_URL
-unzip -o $ZIP_LOCATION -d $BIN_DIR
+unzip -j -o $ZIP_LOCATION -d $BIN_DIR
 rm -f $ZIP_LOCATION
 indent "Downloaded"
 


### PR DESCRIPTION
A follow-on to #51, this PR updates the `unzip` command in `bin/compile` to remove the extra folder created inside `/tmp` when `chromdriver-linux64.zip` is `unzip`ped. 

Before: `/tmp/chromedriver-linux64/chromedriver` (not what we want; risk of not being backward-compatible)
After: `/tmp/chromedriver` (yes)
