### PR TITLE
Improve error message for download errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Improve error message for download errors
 - Update `unzip` step in `bin/compile` to remove superfluous directory from decompressed chromedriver path
 - Update Google's URL to reflect new location for chromedriver downloads
 - Remove Circle CI and add GitHub Action for simple CI

--- a/bin/compile
+++ b/bin/compile
@@ -37,7 +37,7 @@ indent "Version $VERSION"
 topic "Downloading chromedriver v$VERSION"
 ZIP_URL="https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/$VERSION/linux64/chromedriver-linux64.zip"
 ZIP_LOCATION="/tmp/chromedriver.zip"
-curl -s -o $ZIP_LOCATION $ZIP_URL
+curl --silent --show-error --fail --retry 3 --retry-connrefused --connect-timeout 10 -o "${ZIP_LOCATION}" "${ZIP_URL}"
 unzip -j -o $ZIP_LOCATION -d $BIN_DIR
 rm -f $ZIP_LOCATION
 indent "Downloaded"


### PR DESCRIPTION
Previously if the `curl` call to download Chromedriver failed, the curl error message would not be shown, curl would exit zero and instead a confusing unzip error would be seen instead. Now, the build fails earlier, with a more informative error message.

An example of this is seen in #55.

Before (with `CHROMEDRIVER_VERSION` set to the invalid version `999.999.999`):

```
remote: -----> chromedriver app detected
remote: -----> Downloading chromedriver v999.999.999...
remote: Archive:  /tmp/chromedriver.zip
remote:   End-of-central-directory signature not found.  Either this file is not
remote:   a zipfile, or it constitutes one disk of a multi-part archive.  In the
remote:   latter case the central directory and zipfile comment will be found on
remote:   the last disk(s) of this archive.
remote: unzip:  cannot find zipfile directory in one of /tmp/chromedriver.zip or
remote:         /tmp/chromedriver.zip.zip, and cannot find /tmp/chromedriver.zip.ZIP, period.
remote:  !     Push rejected, failed to compile chromedriver app.
```

After:

```
remote: -----> chromedriver app detected
remote: -----> Downloading chromedriver v999.999.999...
remote: curl: (22) The requested URL returned error: 404
remote:  !     Push rejected, failed to compile chromedriver app.
```

GUS-W-13981846.