### PR TITLE
New Chrome-for-Testing install

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -10,6 +10,11 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Run Buildpack Compile
-      run:  ./bin/compile . . .
+      run: ./bin/compile . . .
       env:
         STACK: heroku-22
+
+    - name: Check Installation
+      run: |
+        .chrome-for-testing/bin/chrome --version
+        .chrome-for-testing/bin/chromedriver --version

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -11,3 +11,5 @@ jobs:
 
     - name: Run Buildpack Compile
       run:  ./bin/compile . . .
+      env:
+        STACK: heroku-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Replace with installation of [Chrome for Testing](https://chromedriver.chromium.org/downloads/version-selection), so that Chrome & chromedriver versions are in-sync
 - Explain the source of the chromedriver version in the build log when `CHROMEDRIVER_VERSION` is set
 - Improve error message for download errors
 - Update `unzip` step in `bin/compile` to remove superfluous directory from decompressed chromedriver path

--- a/README.md
+++ b/README.md
@@ -1,26 +1,18 @@
 # heroku-buildpack-chromedriver
 
-This buildpack installs
-[`chromedriver`](https://chromedriver.chromium.org/)
- (the Selenium driver for Chrome) in a Heroku slug.
- 
- This buildpack only installs the `chromedriver` binary. To use Selenium with Chrome
- on Heroku, you'll also need Chrome. We suggest one of these buildpacks:
- 
- - [heroku-buildpack-google-chrome](https://github.com/heroku/heroku-buildpack-google-chrome) 
-   to run Chrome with the `--headless` flag
- - [heroku-buildpack-xvfb-google-chrome](https://github.com/heroku/heroku-buildpack-xvfb-google-chrome)
-   to run Chrome against a virtual window server
-
+This buildpack installs **Google Chrome browser** `chrome` &
+[`chromedriver`](https://chromedriver.chromium.org/), the Selenium driver for Chrome, in a Heroku app.
 
 ## Configuring the downloaded version of chromedriver.
 
-By default, this buildpack will download the latest release, which is provided
-by [Google](https://chromedriver.storage.googleapis.com/LATEST_RELEASE).
+By default, this buildpack will download the latest `Stable` release, which is provided
+by [Google](https://googlechromelabs.github.io/chrome-for-testing/).
 
-You can control the specific version by setting the `CHROMEDRIVER_VERSION`
-variable to an explicit version e.g. `2.39`.
+You can control the channel of the release by setting the `GOOGLE_CHROME_CHANNEL`
+config variable to `Stable`, `Beta`, `Dev`, or `Canary`, and the deploy/build the app.
 
+Chrome is "evergreen", so they do not support downloading specific versions, 
+but instead the latest from any of these channels.
 
 ## Releasing a new version
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ By default, this buildpack will download the latest `Stable` release, which is p
 by [Google](https://googlechromelabs.github.io/chrome-for-testing/).
 
 You can control the channel of the release by setting the `GOOGLE_CHROME_CHANNEL`
-config variable to `Stable`, `Beta`, `Dev`, or `Canary`, and the deploy/build the app.
+config variable to `Stable`, `Beta`, `Dev`, or `Canary`, and then deploy/build the app.
 
 Chrome is "evergreen", so they do not support downloading specific versions, 
 but instead the latest from any of these channels.

--- a/bin/compile
+++ b/bin/compile
@@ -1,13 +1,26 @@
 #!/usr/bin/env bash
 # bin/compile <build-dir> <cache-dir> <env-dir>
 
-set -o errexit
+# fail fast
+set -e
 set -o pipefail
-set -o nounset
-unset GIT_DIR
+
+# debug
+# set -x
+
+# parse and derive params
+BUILD_DIR=$1
+CACHE_DIR=$2
+ENV_DIR=$3
+BUILDPACK_DIR="$(cd "$(dirname "$0")"; cd ..; pwd)"
+
+function error() {
+  echo " !     $*" >&2
+  exit 1
+}
 
 function topic() {
-  echo "-----> $*..."
+  echo "-----> $*"
 }
 
 function indent() {
@@ -18,32 +31,47 @@ function indent() {
   esac
 }
 
-BUILD_DIR=${1:-}
-CACHE_DIR=${2:-}
-ENV_DIR=${3:-}
+topic "Installing Chrome for Testing"
 
-BIN_DIR=$BUILD_DIR/.chromedriver/bin
-mkdir -p $BIN_DIR
+INSTALL_DIR="$BUILD_DIR/.chrome-for-testing"
+BIN_DIR="$INSTALL_DIR/bin"
+mkdir -p "$BIN_DIR"
 
-if [ -f $ENV_DIR/CHROMEDRIVER_VERSION ]; then
-  VERSION=$(cat $ENV_DIR/CHROMEDRIVER_VERSION)
-  topic "Using chromedriver v${VERSION} (set by the env var 'CHROMEDRIVER_VERSION')"
+# Detect requested channel or default to stable
+if [ -f "$ENV_DIR/GOOGLE_CHROME_CHANNEL" ]; then
+  channel=$(cat "$ENV_DIR/GOOGLE_CHROME_CHANNEL")
+  echo "Using env var GOOGLE_CHROME_CHANNEL=$channel" | indent
 else
-  topic "Looking up latest chromedriver version"
-  LATEST="https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json"
-  VERSION=$(curl --silent --show-error --fail --retry 3 --retry-connrefused --connect-timeout 10 "${LATEST}" | jq -r '.channels.Stable.version')
+  channel=stable
 fi
-indent "Version $VERSION"
+# The current version endpoint requires ALL CAPS.
+CHANNEL="$(echo -n "$channel" | awk '{ print toupper($0) }')"
+VERSION="$(curl --silent --show-error --fail --retry 3 --retry-connrefused --connect-timeout 10 "https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_$CHANNEL")"
+echo "Resolved $CHANNEL version $VERSION" | indent
 
-topic "Downloading chromedriver v$VERSION"
+echo "Downloading Chrome" | indent
+ZIP_URL="https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/$VERSION/linux64/chrome-linux64.zip"
+ZIP_LOCATION="$INSTALL_DIR/chrome.zip"
+curl --silent --show-error --fail --retry 3 --retry-connrefused --connect-timeout 10 -o "${ZIP_LOCATION}" "${ZIP_URL}" | indent
+unzip -q -j -o "$ZIP_LOCATION" -d "$BIN_DIR" | indent
+rm -f "$ZIP_LOCATION"
+
+echo "Downloading Chromedriver" | indent
 ZIP_URL="https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/$VERSION/linux64/chromedriver-linux64.zip"
-ZIP_LOCATION="/tmp/chromedriver.zip"
-curl --silent --show-error --fail --retry 3 --retry-connrefused --connect-timeout 10 -o "${ZIP_LOCATION}" "${ZIP_URL}"
-unzip -j -o $ZIP_LOCATION -d $BIN_DIR
-rm -f $ZIP_LOCATION
-indent "Downloaded"
+ZIP_LOCATION="$INSTALL_DIR/chromedriver.zip"
+curl --silent --show-error --fail --retry 3 --retry-connrefused --connect-timeout 10 -o "${ZIP_LOCATION}" "${ZIP_URL}" | indent
+unzip -q -j -o "$ZIP_LOCATION" -d "$BIN_DIR" | indent
+rm -f "$ZIP_LOCATION"
 
-topic "Creating chromedriver export scripts"
-mkdir -p $BUILD_DIR/.profile.d
-echo "export PATH=\$PATH:\$HOME/.chromedriver/bin" >> $BUILD_DIR/.profile.d/chromedriver.sh
-indent "Created"
+source "$BUILDPACK_DIR/bin/install-chrome-dependencies"
+
+echo "Adding executables to PATH" | indent
+mkdir -p "$BUILD_DIR/.profile.d"
+echo "export PATH=\$HOME/.chrome-for-testing/bin:\$PATH" >> "$BUILD_DIR/.profile.d/chrome-for-testing.sh"
+
+# Verify the executables are actually present
+export PATH="$BUILD_DIR/.chrome-for-testing/bin:$PATH"
+which chrome | indent
+which chromedriver | indent
+
+echo "Installed Chrome for Testing $CHANNEL version $VERSION" | indent

--- a/bin/compile
+++ b/bin/compile
@@ -44,7 +44,7 @@ fi
 
 # Detect if Chrome is already installed
 if which chrome; then
-  error "Chrome is already installed. This buildpack now install a compatible version of Chrome. Please, remove the other Chrome installation."
+  error "Chrome is already installed. This buildpack now installs a compatible version of Chrome. Please, remove the other Chrome installation. Chrome may have been installed by another buildpack (such as heroku/heroku-buildpack-google-chrome buildpack), which should no longer be used with this buildpack."
 fi
 
 # Detect requested channel or default to stable

--- a/bin/compile
+++ b/bin/compile
@@ -37,6 +37,16 @@ INSTALL_DIR="$BUILD_DIR/.chrome-for-testing"
 BIN_DIR="$INSTALL_DIR/bin"
 mkdir -p "$BIN_DIR"
 
+# Detect if the old config var is still used
+if [ -f "$ENV_DIR/CHROMEDRIVER_VERSION" ]; then
+  error "This buildpack no longer supports CHROMEDRIVER_VERSION config var and must be removed to continue, because this buildpack now installs compatible versions of Chrome & Chromedriver. GOOGLE_CHROME_CHANNEL can be used to set Stable (default), Beta, Dev, or Canary."
+fi
+
+# Detect if Chrome is already installed
+if which chrome; then
+  error "Chrome is already installed. This buildpack now install a compatible version of Chrome. Please, remove the other Chrome installation."
+fi
+
 # Detect requested channel or default to stable
 if [ -f "$ENV_DIR/GOOGLE_CHROME_CHANNEL" ]; then
   channel=$(cat "$ENV_DIR/GOOGLE_CHROME_CHANNEL")

--- a/bin/detect
+++ b/bin/detect
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # bin/detect <build-dir>
 
-echo "chromedriver"
+echo "Chrome for Testing"
 exit 0

--- a/bin/install-chrome-dependencies
+++ b/bin/install-chrome-dependencies
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Invoke with `source "$BUILDPACK_DIR/bin/install-chrome-dependencies"` from inside `bin/compile`.
+# This script is mostly copied from:
+#  https://github.com/heroku/heroku-buildpack-google-chrome/blob/master/bin/compile
+
+# Uses variables & methods from compile script:
+# BUILD_DIR
+# CACHE_DIR
+# ENV_DIR
+# BUILDPACK_DIR
+# topic()
+# indent()
+
+topic "Installing Chrome dependencies"
+
+# Install correct dependencies according to $STACK
+case "${STACK}" in
+  "heroku-18" | "heroku-20" | "heroku-22")
+    # the package list is found by using ci:debug then running ldd $GOOGLE_CHROME_BIN | grep not
+    # also look here for more packages/notes https://developers.google.com/web/tools/puppeteer/troubleshooting
+    PACKAGES="
+      gconf-service
+      libappindicator1
+      libasound2
+      libatk1.0-0
+      libatk-bridge2.0-0
+      libcairo-gobject2
+      libdrm2
+      libgbm1
+      libgconf-2-4
+      libgtk-3-0
+      libnspr4
+      libnss3
+      libx11-xcb1
+      libxcb-dri3-0
+      libxcomposite1
+      libxcursor1
+      libxdamage1
+      libxfixes3
+      libxi6
+      libxinerama1
+      libxrandr2
+      libxshmfence1
+      libxss1
+      libxtst6
+      fonts-liberation
+    "
+    ;;
+  *)
+    error "STACK must be 'heroku-18', 'heroku-20' or 'heroku-22', not '${STACK}'."
+esac
+
+if [ ! -f $CACHE_DIR/PURGED_CACHE_V1 ]; then
+  echo "Purging cache" | indent
+  rm -rf $CACHE_DIR/apt
+  rm -rf $CACHE_DIR/archives
+  rm -rf $CACHE_DIR/lists
+  touch $CACHE_DIR/PURGED_CACHE_V1
+fi
+
+# This is where the original buildpack installed Chrome itself, 
+# but Chrome for Testing is installed from direct downloads.
+#
+# echo "Installing Google Chrome from the $channel channel." | indent
+# PACKAGES="$PACKAGES https://dl.google.com/linux/direct/google-chrome-${channel}_current_amd64.deb"
+
+APT_CACHE_DIR="$CACHE_DIR/apt/cache"
+APT_STATE_DIR="$CACHE_DIR/apt/state"
+
+mkdir -p "$APT_CACHE_DIR/archives/partial"
+mkdir -p "$APT_STATE_DIR/lists/partial"
+
+APT_OPTIONS="-o debug::nolocking=true -o dir::cache=$APT_CACHE_DIR -o dir::state=$APT_STATE_DIR"
+
+echo "Updating apt caches" | indent
+apt-get $APT_OPTIONS update | indent
+
+for PACKAGE in $PACKAGES; do
+  if [[ $PACKAGE == *deb ]]; then
+    PACKAGE_NAME=$(basename $PACKAGE .deb)
+    PACKAGE_FILE=$APT_CACHE_DIR/archives/$PACKAGE_NAME.deb
+
+    echo "Fetching $PACKAGE" | indent
+    curl -s -L -z $PACKAGE_FILE -o $PACKAGE_FILE $PACKAGE 2>&1 | indent
+  else
+    echo "Fetching .debs for $PACKAGE" | indent
+    apt-get $APT_OPTIONS -y --force-yes -d install --reinstall $PACKAGE | indent
+  fi
+done
+
+mkdir -p $BUILD_DIR/.apt
+
+for DEB in $(ls -1 $APT_CACHE_DIR/archives/*.deb); do
+  echo "Installing $(basename $DEB)" | indent
+  dpkg -x $DEB $BUILD_DIR/.apt/
+done
+
+echo "Writing profile script" | indent
+mkdir -p $BUILD_DIR/.profile.d
+cat <<EOF >$BUILD_DIR/.profile.d/000_apt.sh
+export PATH="\$HOME/.apt/usr/bin:\$PATH"
+export LD_LIBRARY_PATH="\$HOME/.apt/usr/lib/x86_64-linux-gnu:\$HOME/.apt/usr/lib/i386-linux-gnu:\$HOME/.apt/usr/lib:\$LD_LIBRARY_PATH"
+export LIBRARY_PATH="\$HOME/.apt/usr/lib/x86_64-linux-gnu:\$HOME/.apt/usr/lib/i386-linux-gnu:\$HOME/.apt/usr/lib:\$LIBRARY_PATH"
+export INCLUDE_PATH="\$HOME/.apt/usr/include:\$HOME/.apt/usr/include/x86_64-linux-gnu:\$INCLUDE_PATH"
+export CPATH="\$INCLUDE_PATH"
+export CPPPATH="\$INCLUDE_PATH"
+export PKG_CONFIG_PATH="\$HOME/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:\$HOME/.apt/usr/lib/i386-linux-gnu/pkgconfig:\$HOME/.apt/usr/lib/pkgconfig:\$PKG_CONFIG_PATH"
+EOF
+
+export PATH="$BUILD_DIR/.apt/usr/bin:$PATH"
+export LD_LIBRARY_PATH="$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu:$BUILD_DIR/.apt/usr/lib/i386-linux-gnu:$BUILD_DIR/.apt/usr/lib:$LD_LIBRARY_PATH"
+export LIBRARY_PATH="$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu:$BUILD_DIR/.apt/usr/lib/i386-linux-gnu:$BUILD_DIR/.apt/usr/lib:$LIBRARY_PATH"
+export INCLUDE_PATH="$BUILD_DIR/.apt/usr/include:$BUILD_DIR/.apt/usr/include/x86_64-linux-gnu:$INCLUDE_PATH"
+export CPATH="$INCLUDE_PATH"
+export CPPPATH="$INCLUDE_PATH"
+export PKG_CONFIG_PATH="$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:$BUILD_DIR/.apt/usr/lib/i386-linux-gnu/pkgconfig:$BUILD_DIR/.apt/usr/lib/pkgconfig:$PKG_CONFIG_PATH"
+
+#give environment to later buildpacks
+export | grep -E -e ' (PATH|LD_LIBRARY_PATH|LIBRARY_PATH|INCLUDE_PATH|CPATH|CPPPATH|PKG_CONFIG_PATH)='  > "$BUILDPACK_DIR/export"
+
+echo "Rewrite package-config files" | indent
+find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs --no-run-if-empty -n 1 sed -i -e 's!^prefix=\(.*\)$!prefix='"$BUILD_DIR"'/.apt\1!g'
+
+echo "Installed Chrome dependencies for $STACK" | indent

--- a/bin/install-chrome-dependencies
+++ b/bin/install-chrome-dependencies
@@ -118,7 +118,4 @@ export PKG_CONFIG_PATH="$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:$BUIL
 #give environment to later buildpacks
 export | grep -E -e ' (PATH|LD_LIBRARY_PATH|LIBRARY_PATH|INCLUDE_PATH|CPATH|CPPPATH|PKG_CONFIG_PATH)='  > "$BUILDPACK_DIR/export"
 
-echo "Rewrite package-config files" | indent
-find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs --no-run-if-empty -n 1 sed -i -e 's!^prefix=\(.*\)$!prefix='"$BUILD_DIR"'/.apt\1!g'
-
 echo "Installed Chrome dependencies for $STACK" | indent


### PR DESCRIPTION
In summer 2023, the Chrome development team [addressed a long-standing problem with keeping Chrome & Chromedriver versions updated and aligned](https://developer.chrome.com/blog/chrome-for-testing/) with each other for automated testing environments.

This changeset switches over to a `bin/compile` process that follows this new provision from the Chrome development team, so that `chrome` & `chromedriver` version are in-sync.

⚠️  This buildpack now installs `chrome` browser, so remove the separate `heroku/google-chrome` buildpack from the Heroku app.


### To Do

- [x]  detect pre-existing `chrome` executable, and fail the build with clear error message to remove other Chrome buildpacks/installations
- [x] fail when `CHROMEDRIVER_VERSION` is still set, because it is no longer used by this buildpack
- [x] fix CI tests for new `compile` process