### PR TITLE
Caution: Use Chrome for Testing buildpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- End-of-life: redirect developers to Chrome for Testing buildpack
 - Explain the source of the chromedriver version in the build log when `CHROMEDRIVER_VERSION` is set
 - Improve error message for download errors
 - Update `unzip` step in `bin/compile` to remove superfluous directory from decompressed chromedriver path

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # heroku-buildpack-chromedriver
 
+> [!CAUTION]
+> This buildpack should no longer be used. The Chromedriver version falls out of sync with Chrome (installed by a different buildpack) causing build failures.
+> 
+> **Instead, please use [Chrome for Testing buildpack](https://github.com/heroku/heroku-buildpack-chrome-for-testing)**, which installs  [matching Chrome + Chromedriver versions](https://googlechromelabs.github.io/chrome-for-testing/).
+
+-----
+
+# Original README
+
 This buildpack installs
 [`chromedriver`](https://chromedriver.chromium.org/)
  (the Selenium driver for Chrome) in a Heroku slug.

--- a/bin/compile
+++ b/bin/compile
@@ -18,6 +18,34 @@ function indent() {
   esac
 }
 
+ANSI_RED="\033[1;31m"
+ANSI_RESET="\033[0m"
+
+function display_error() {
+  echo >&2
+  # We have to ANSI wrap each line separately to prevent breakage if line prefixes are added
+  # later (such as when the builder is untrusted, or when Git adds the "remote:" prefix).
+  while IFS= read -r line; do
+    echo -e "${ANSI_RED}${line}${ANSI_RESET}" >&2
+  done <<< "${1}"
+  echo >&2
+}
+
+display_error "$(cat <<'EOF'
+#######################################################################
+
+WARNING: The Chromedriver buildpack should no longer be used. The 
+installed version falls out of sync with Chrome (installed by a 
+different buildpack) causing build failures.
+
+Instead, please use "Chrome for Testing" buildpack, 
+https://github.com/heroku/heroku-buildpack-chrome-for-testing
+which installs matching Chrome + Chromedriver versions.
+
+#######################################################################
+EOF
+)"
+
 BUILD_DIR=${1:-}
 CACHE_DIR=${2:-}
 ENV_DIR=${3:-}


### PR DESCRIPTION
Redirect developers to use the recently released Chrome for Testing buildpack.

See the [rendered README](https://github.com/heroku/heroku-buildpack-chromedriver/blob/caution-use-chrome-for-testing/README.md).